### PR TITLE
Added a Filter to notification send invoke

### DIFF
--- a/gravityforms-cron/gravityforms-cron.php
+++ b/gravityforms-cron/gravityforms-cron.php
@@ -139,7 +139,11 @@ function gfc_send_cron_notification( $options) {
 	$event = $options->event;
 	$form = GFAPI::get_form($options->form_id);
 	$lead = GFAPI::get_entry($options->entry_id);
-	GFCommon::send_notifications( $options->notifications, $form, $lead, true, $event );
+	
+	// add a filter to alter the notifications to send (it is too late to use gform_disable_notification)
+	$notifications_to_send = apply_filters('gfc_notifications_to_send', $options->notifications, $form, $lead);
+	
+	GFCommon::send_notifications( $notifications_to_send, $form, $lead, true, $event );
 	die();
 }
 


### PR DESCRIPTION
Just passing the $options->notifications into apply_filters.

For example, I'm sending a payment reminder as delayed notification, containing a [Paypal payment URL](https://github.com/ethanclevenger91/gravity-forms-payment-continue) after 30 minutes a user submits the form, but if meanwhile the user fullfills the payment (for example using Paypal Standard addon), you can unset the notification as it has no more reason to be sent.

Like this:

```
add_filter(  'gfc_notifications_to_send',  'disable_delayed_notifications', 10, 3  );
function disable_delayed_notifications( $notifications, $form, $entry ){
 
 	foreach ( $notifications as $key => $value ){
 		$notification_message   = $form['notifications'][$value]['message'];
 		$is_payment_url		= ( strpos( $notification_message, '{payment_url}' ) !== false );
 		$is_payment_waiting	= ( $entry['payment_status'] == 'Processing' || $entry['payment_status'] == 'Pending' );

 		if( $is_payment_url && ! $is_payment_waiting ){
			unset( $notifications[$key] );
		}
 	}
 	
 	return $notifications;
 }
```